### PR TITLE
Doens't work when JSON starts with array

### DIFF
--- a/json-reformat-test.el
+++ b/json-reformat-test.el
@@ -71,3 +71,31 @@
 }" (json-reformat:tree-to-string
     '("info" ("male" t) "age" 33 "name" "John Smith") 0)))
   )
+
+(ert-deftest json-reformat-test:json-reformat-region ()
+  (should (string= "\
+{
+    \"breakfast\": \[
+        \"milk\",
+        \"bread\",
+        \"egg\"
+    \],
+    \"age\": 33,
+    \"name\": \"John Smith\"
+}" (with-temp-buffer
+     (insert "{\"name\": \"John Smith\", \"age\": 33, \"breakfast\":\[\"milk\", \"bread\", \"egg\"\]}")
+     (json-reformat-region (point-min) (point-max))
+     (buffer-string))))
+
+  (should (string= "\
+\[
+    {
+        \"foo\": \"bar\"
+    },
+    {
+        \"foo\": \"baz\"
+    }
+\]" (with-temp-buffer
+     (insert "[{ \"foo\" : \"bar\" }, { \"foo\" : \"baz\" }]")
+     (json-reformat-region (point-min) (point-max))
+     (buffer-string)))))

--- a/json-reformat.el
+++ b/json-reformat.el
@@ -107,7 +107,7 @@
              (before (buffer-substring (point-min) (point-max)))
              (json-tree (json-read-from-string before))
              after)
-        (setq after (json-reformat:tree-to-string json-tree 0))
+        (setq after (json-reformat:print-node json-tree 0))
         (delete-region (point-min) (point-max))
         (insert after)))))
 


### PR DESCRIPTION
Hello, try to reformat a simple file with `[{}]` and it fails. In my case I receive JSON containing an array of hashes... something like `[{ "foo" : "bar" }, { "foo" : "baz" }]`
