### PR TITLE
Use evm on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: emacs-lisp
 env:
   matrix:
-    - EMACS_VERSION=23.4
     - EMACS_VERSION=24.1
     - EMACS_VERSION=24.2
     - EMACS_VERSION=24.3


### PR DESCRIPTION
- [rejeep/evm](https://github.com/rejeep/evm)
- [Emacsのバージョンマネージャ "evm" がEmacs LispのCIにおすすめ - Copy/Cut/Paste/Hatena](http://k1low.hatenablog.com/entry/2014/04/15/203856)
- [Library s not found after installed by cask? · Issue #172 · cask/cask](https://github.com/cask/cask/issues/172#issuecomment-32716449)
