### PR TITLE
Re-encode strings back, so result stays valid JSON

### DIFF
--- a/json-reformat.el
+++ b/json-reformat.el
@@ -57,7 +57,7 @@
         (t (symbol-name val))))
 
 (defun json-reformat:decode-string (val)
-  (format "\"%s\"" val))
+  (json-encode-string val))
 
 (defun json-reformat:vector-to-string (val level)
   (if (= (length val) 0) "[]"


### PR DESCRIPTION
Otherwise any string containing quotes will break resulting JSON
