### PR TITLE
Display error information when occurs JSON parse error

### DIFF
--- a/json-reformat.el
+++ b/json-reformat.el
@@ -167,18 +167,26 @@ If you want to customize the reformat style,
 please see the documentation of `json-reformat:indent-width'
 and `json-reformat:pretty-string?'."
   (interactive "r")
-  (save-excursion
-    (save-restriction
-      (narrow-to-region begin end)
-      (goto-char (point-min))
-      (let* ((json-key-type 'string)
-             (json-object-type 'plist)
-             (before (buffer-substring (point-min) (point-max)))
-             (json-tree (json-read-from-string before))
-             after)
-        (setq after (json-reformat:print-node json-tree 0))
-        (delete-region (point-min) (point-max))
-        (insert after)))))
+  (let ((start-line (line-number-at-pos begin))
+        (json-key-type 'string)
+        (json-object-type 'plist))
+    (save-excursion
+      (save-restriction
+        (narrow-to-region begin end)
+        (goto-char (point-min))
+        (let (json-tree reformatted)
+          (condition-case errvar
+              (progn
+                (setq json-tree (json-read))
+                (setq reformatted (json-reformat:print-node json-tree 0))
+                (delete-region (point-min) (point-max))
+                (insert reformatted))
+            (error
+             (message
+              "JSON parse error [Reason] %s [Position] In buffer, line %d (char %d)"
+              (error-message-string errvar)
+              (+ start-line (line-number-at-pos (point)) -1)
+              (point)))))))))
 
 (provide 'json-reformat)
 

--- a/test/json-reformat-test.el
+++ b/test/json-reformat-test.el
@@ -116,3 +116,26 @@ bar\"" (json-reformat:string-to-string "fo\"o\nbar")))
      (insert "[{ \"foo\" : \"bar\" }, { \"foo\" : \"baz\" }]")
      (json-reformat-region (point-min) (point-max))
      (buffer-string)))))
+
+(ert-deftest json-reformat-test:json-reformat-region-occur-error ()
+  (let (message-string)
+    (cl-letf (((symbol-function 'message) (lambda (&rest args) (setq message-string (apply 'format args)))))
+      ;; missing camma after "milk"
+      (with-temp-buffer
+        (insert "{\"name\": \"John Smith\", \"age\": 33, \"breakfast\":\[\"milk\" \"bread\", \"egg\"\]}")
+        (json-reformat-region (point-min) (point-max)))
+      (should (string=
+               "JSON parse error [Reason] Unknown JSON error: bleah [Position] In buffer, line 1 (char 55)"
+               message-string))
+
+      ;; The `foo' key don't start with '"'
+      (with-temp-buffer
+        (insert "\
+
+
+[{ foo : \"bar\" }, { \"foo\" : \"baz\" }]") ;; At 3 (line)
+        (json-reformat-region (point-min) (point-max)))
+      (should (string=
+               "JSON parse error [Reason] Bad string format: \"doesn't start with '\\\"'!\" [Position] In buffer, line 3 (char 6)"
+               message-string))
+      )))


### PR DESCRIPTION
See:  GH-19

![reformatter-error-display](https://cloud.githubusercontent.com/assets/124713/6731190/6e42ebfa-ce86-11e4-9df8-ab773d391812.gif)
