### PR TITLE
Change `json-object-type` plist to hash-table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,17 @@ branches:
   only:
     - master
 
+matrix:
+  allow_failures:
+    - env: EMACS=emacs-snapshot EMACS_PPA=ppa:ubuntu-elisp/ppa
+
 env:
   matrix:
     - EMACS=emacs24        EMACS_PPA=ppa:cassou/emacs
-  allow_failures:
     - EMACS=emacs-snapshot EMACS_PPA=ppa:ubuntu-elisp/ppa
   global:
     - PATH=$HOME/.cask/bin:$PATH
+
 before_install:
   - sudo add-apt-repository -y "$EMACS_PPA"
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: emacs-lisp
+
+branches:
+  only:
+    - master
+
 env:
   matrix:
     - EMACS=emacs24        EMACS_PPA=ppa:cassou/emacs

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ branches:
 env:
   matrix:
     - EMACS=emacs24        EMACS_PPA=ppa:cassou/emacs
+  allow_failures:
     - EMACS=emacs-snapshot EMACS_PPA=ppa:ubuntu-elisp/ppa
   global:
     - PATH=$HOME/.cask/bin:$PATH

--- a/json-reformat.el
+++ b/json-reformat.el
@@ -47,8 +47,15 @@
 ;;; Code:
 
 (require 'json)
-(require 'subr-x)
 (eval-when-compile (require 'cl))
+
+(unless (featurep 'subr-x)
+  ;; built-in subr-x from 24.4
+  (defsubst hash-table-keys (hash-table)
+    "Return a list of keys in HASH-TABLE."
+    (let ((keys '()))
+      (maphash (lambda (k _v) (push k keys)) hash-table)
+      keys)))
 
 (defconst json-reformat:special-chars-as-pretty-string
   '((?\" . ?\")

--- a/json-reformat.el
+++ b/json-reformat.el
@@ -105,7 +105,7 @@ Else t:
         (t (symbol-name val))))
 
 (defun json-reformat:encode-char-as-pretty (char)
-  (setq char (json-encode-char0 char 'ucs))
+  (setq char (encode-char char 'ucs))
   (let ((special-char (car (rassoc char json-reformat:special-chars-as-pretty-string))))
     (if special-char
         (format "\\%c" special-char)

--- a/test/json-reformat-test.el
+++ b/test/json-reformat-test.el
@@ -78,7 +78,9 @@ bar\"" (json-reformat:string-to-string "fo\"o\nbar")))
   )
 
 (ert-deftest json-reformat-test:tree-to-string ()
-  (should (string= "\
+  (let ((info (make-hash-table :test 'equal)))
+    (puthash "male" t info)
+    (should (string= "\
 {
     \"info\": {
         \"male\": true
@@ -86,8 +88,8 @@ bar\"" (json-reformat:string-to-string "fo\"o\nbar")))
     \"age\": 33,
     \"name\": \"John Smith\"
 }" (json-reformat:tree-to-string
-    '("info" ("male" t) "age" 33 "name" "John Smith") 0)))
-  )
+    `("info" ,info "age" 33 "name" "John Smith") 0)))
+    ))
 
 (ert-deftest json-reformat-test:json-reformat-region ()
   (should (string= "\

--- a/test/json-reformat-test.el
+++ b/test/json-reformat-test.el
@@ -117,6 +117,16 @@ bar\"" (json-reformat:string-to-string "fo\"o\nbar")))
 \]" (with-temp-buffer
      (insert "[{ \"foo\" : \"bar\" }, { \"foo\" : \"baz\" }]")
      (json-reformat-region (point-min) (point-max))
+     (buffer-string))))
+
+  (should (string= "\
+{
+    \"foo\": {
+    },
+    \"bar\": null
+}" (with-temp-buffer
+     (insert "{\"foo\" : {}, \"bar\" : null}")
+     (json-reformat-region (point-min) (point-max))
      (buffer-string)))))
 
 (ert-deftest json-reformat-test:json-reformat-region-occur-error ()


### PR DESCRIPTION
## Introduction

Plan to modify the following code:

https://github.com/gongo/json-reformat/blob/0.0.3/json-reformat.el#L172

```diff
- (json-object-type 'plist))
+ (json-object-type 'hash-table))
```

## Motivation

Currently, `json-reformat` has the following issues:

- GH-23
- https://github.com/gongo/json-reformat/issues/17#issuecomment-78046968

```lisp
(let ((json-object-type 'plist))
  (json-read-from-string "{\"foo\": {}}")   ;; => (:foo nil)
  (json-read-from-string "{\"foo\": null}") ;; => (:foo nil). Same..
  )
```

Therefore:

```lisp
(with-temp-buffer
  (insert "{\"foo\": {}}")
  (json-reformat-region (point-min) (point-max))
  (buffer-string))

;; => {
;;        "foo": null
;;    }

(with-temp-buffer
  (insert "{\"foo\": null}")
  (json-reformat-region (point-min) (point-max))
  (buffer-string))

;; => {
;;        "foo": null
;;    }
```

**Irreversible** !! (`{}` -> `"null"` -> not `{}`)

## If use `hash-table`

```lisp
(let ((json-object-type 'hash-table))
  (setq t1 (json-read-from-string "{\"foo\": {}}"))
  (setq t2 (json-read-from-string "{\"foo\": null}")))

(gethash "foo" t1) ;; => #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ( ...))
(gethash "foo" t2) ;; => null
```

Distinguishable!! :tada: 