### PR TITLE
Load subr-x for using hash-table-keys

### DIFF
--- a/json-reformat.el
+++ b/json-reformat.el
@@ -49,7 +49,7 @@
 (require 'json)
 (eval-when-compile (require 'cl))
 
-(unless (featurep 'subr-x)
+(unless (require 'subr-x nil t)
   ;; built-in subr-x from 24.4
   (defsubst hash-table-keys (hash-table)
     "Return a list of keys in HASH-TABLE."


### PR DESCRIPTION
subr-x.el is not loaded by default. json-reformat.el defines hash-table-keys
even for Emacs 24.4 or higher if subr-x is not loaded yet.