### PR TITLE
Signal error when buffer read-only

### DIFF
--- a/json-reformat.el
+++ b/json-reformat.el
@@ -169,7 +169,7 @@ Else t:
 If you want to customize the reformat style,
 please see the documentation of `json-reformat:indent-width'
 and `json-reformat:pretty-string?'."
-  (interactive "r")
+  (interactive "*r")
   (let ((start-line (line-number-at-pos begin))
         (json-key-type 'string)
         (json-object-type 'hash-table))


### PR DESCRIPTION
A buffer changed command should be pre-check buffer is read-only.

see also:
http://www.gnu.org/software/emacs/manual/html_node/elisp/Using-Interactive.html

> If ‘*’ appears at the beginning of the string, then an error is signaled if the buffer is read-only.
